### PR TITLE
Add transparent beam search with Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 data
 outputs
+*.pyc

--- a/python/transparent_beam_search_plot.py
+++ b/python/transparent_beam_search_plot.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 from scratch import PyVectorDataset, PyVectorGraph
 from utils import fbin_to_numpy, graph_file_to_list_of_lists
+import os
 
 
 def main():
@@ -36,7 +37,12 @@ def main():
     plt.ylabel("Log Rank")
     plt.title("Transparent Beam Search Rank Progress")
     plt.tight_layout()
-    plt.savefig("beam_search_progress.png")
+    
+    # ensure the output directory exists
+    output_dir = "../outputs/plots"
+    os.makedirs(output_dir, exist_ok=True)
+    plt.savefig(os.path.join(output_dir, "transparent_beam_search_rank_progress.png"))
+    plt.show()
 
 
 if __name__ == "__main__":

--- a/python/transparent_beam_search_plot.py
+++ b/python/transparent_beam_search_plot.py
@@ -1,0 +1,33 @@
+import matplotlib.pyplot as plt
+import numpy as np
+from scratch import PyVectorDataset, PyVectorGraph
+from utils import fbin_to_numpy, graph_file_to_list_of_lists
+
+
+def main():
+    data_path = "../data/word2vec-google-news-300_50000_lowercase/base.fbin"
+    graph_path = "../data/word2vec-google-news-300_50000_lowercase/outputs/vamana"
+
+    vectors = fbin_to_numpy(data_path)
+    dataset = PyVectorDataset(vectors)
+
+    neighborhoods = graph_file_to_list_of_lists(graph_path)
+    graph = PyVectorGraph(neighborhoods)
+
+    query = dataset.get_vector(0)
+
+    _frontier, _visited, steps = graph.transparent_beam_search(query, dataset, 0, 10, None)
+
+    distances = [dataset.compare(query, step[1]) for step in steps]
+
+    plt.figure()
+    plt.plot(range(len(distances)), np.log(distances))
+    plt.xlabel("Step")
+    plt.ylabel("Log Distance")
+    plt.title("Transparent Beam Search Distances")
+    plt.tight_layout()
+    plt.savefig("beam_search_progress.png")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/transparent_beam_search_plot.py
+++ b/python/transparent_beam_search_plot.py
@@ -16,15 +16,22 @@ def main():
 
     query = dataset.get_vector(0)
 
-    _frontier, _visited, steps = graph.transparent_beam_search(query, dataset, 0, 10, None)
+    _frontier, _visited, steps = graph.transparent_beam_search(
+        query, dataset, 0, 10, None
+    )
 
-    distances = [dataset.compare(query, step[1]) for step in steps]
+    # Precompute the rank of each dataset point based on distance to the query
+    brute_force = dataset.brute_force(query)
+    ordered_ids = [idx for idx, _ in brute_force]
+    rank = {idx: i for i, idx in enumerate(ordered_ids)}
+
+    log_ranks = [np.log(rank[step[1]] + 1) for step in steps]
 
     plt.figure()
-    plt.plot(range(len(distances)), np.log(distances))
+    plt.plot(range(len(log_ranks)), log_ranks)
     plt.xlabel("Step")
-    plt.ylabel("Log Distance")
-    plt.title("Transparent Beam Search Distances")
+    plt.ylabel("Log Rank")
+    plt.title("Transparent Beam Search Rank Progress")
     plt.tight_layout()
     plt.savefig("beam_search_progress.png")
 

--- a/python/transparent_beam_search_plot.py
+++ b/python/transparent_beam_search_plot.py
@@ -14,7 +14,7 @@ def main():
     neighborhoods = graph_file_to_list_of_lists(graph_path)
     graph = PyVectorGraph(neighborhoods)
 
-    query = dataset.get_vector(0)
+    query = dataset.get_vector(10_000)
 
     _frontier, _visited, steps = graph.transparent_beam_search(
         query, dataset, 0, 10, None
@@ -26,6 +26,9 @@ def main():
     rank = {idx: i for i, idx in enumerate(ordered_ids)}
 
     log_ranks = [np.log(rank[step[1]] + 1) for step in steps]
+    # print("Steps:", steps)
+    # print("Log Ranks:", log_ranks)
+    # print("Distances:", [dataset.compare(query, step[1]) for step in steps])
 
     plt.figure()
     plt.plot(range(len(log_ranks)), log_ranks)

--- a/src/bin/build_slow_preprocessing.rs
+++ b/src/bin/build_slow_preprocessing.rs
@@ -6,7 +6,7 @@ use rand_distr::num_traits::ToPrimitive;
 use rayon::prelude::*;
 use scratch::constructions::slow_preprocessing::build_global_local_graph;
 use scratch::constructions::neighbor_selection::{incremental_greedy, PairwiseDistancesHandler};
-use scratch::data_handling::dataset::{Subset, VectorDataset};
+use scratch::data_handling::dataset::VectorDataset;
 use scratch::data_handling::dataset_traits::Dataset;
 use scratch::data_handling::fbin::{read_fbin, read_fbin_subset};
 use scratch::graph::{beam_search, ClassicGraph, Graph, IndexT};

--- a/src/data_handling/subset.rs
+++ b/src/data_handling/subset.rs
@@ -46,6 +46,7 @@ impl <T: Numeric> Dataset<T> for Subset<T> {
         self.indices.len()
     }
     fn get(&self, i: usize) -> &[T] {
-        self.get(i)
+        let orig_idx = self.indices[i];
+        self.dataset.get(orig_idx)
     }
 }

--- a/src/graph/beam_search.rs
+++ b/src/graph/beam_search.rs
@@ -4,8 +4,13 @@ use rand_distr::num_traits::ToPrimitive;
 
 use crate::data_handling::dataset_traits::Dataset;
 use crate::graph::{Graph, IndexT};
-use std::collections::HashSet;
 
+#[derive(Clone, Debug)]
+pub struct TransparentBeamStep {
+    pub beam: Vec<IndexT>,
+    pub expanded: IndexT,
+}
+use std::collections::HashSet;
 
 pub fn beam_search_with_visited<T>(
     query: &[T],
@@ -15,19 +20,24 @@ pub fn beam_search_with_visited<T>(
     beam_width: usize,
     limit: Option<usize>,
 ) -> (Vec<(IndexT, f32)>, Vec<(IndexT, f32)>) {
-    let mut frontier: Vec<(IndexT, f32)> = vec![(start, dataset.compare(query, start as usize).to_f32().unwrap())];
+    let mut frontier: Vec<(IndexT, f32)> = vec![(
+        start,
+        dataset.compare(query, start as usize).to_f32().unwrap(),
+    )];
     frontier.reserve(beam_width);
 
     let mut seen: HashSet<IndexT> = HashSet::new();
     seen.insert(start);
     let mut visited: Vec<(IndexT, f32)> = vec![];
 
-    while let Some(current) = frontier.iter().find(|x| !visited.contains(x)) {
-        visited.push(*current);
+    while let Some(pos) = frontier.iter().position(|x| !visited.contains(x)) {
+        let current = frontier[pos];
+        visited.push(current);
         let neighbors = graph.neighbors(current.0);
 
         for &neighbor in neighbors {
-            if seen.insert(neighbor) { // true if not already seen
+            if seen.insert(neighbor) {
+                // true if not already seen
                 let dist = dataset.compare(query, neighbor as usize).to_f32().unwrap();
                 frontier.push((neighbor, dist));
             }
@@ -52,6 +62,62 @@ pub fn beam_search_with_visited<T>(
     (frontier, visited)
 }
 
+pub fn transparent_beam_search<T>(
+    query: &[T],
+    graph: &dyn Graph,
+    dataset: &dyn Dataset<T>,
+    start: IndexT,
+    beam_width: usize,
+    limit: Option<usize>,
+) -> (
+    Vec<(IndexT, f32)>,
+    Vec<(IndexT, f32)>,
+    Vec<TransparentBeamStep>,
+) {
+    let mut frontier: Vec<(IndexT, f32)> = vec![(
+        start,
+        dataset.compare(query, start as usize).to_f32().unwrap(),
+    )];
+    frontier.reserve(beam_width);
+
+    let mut seen: HashSet<IndexT> = HashSet::new();
+    seen.insert(start);
+    let mut visited: Vec<(IndexT, f32)> = vec![];
+    let mut steps: Vec<TransparentBeamStep> = Vec::new();
+
+    while let Some(pos) = frontier.iter().position(|x| !visited.contains(x)) {
+        let current = frontier[pos];
+        visited.push(current);
+        let neighbors = graph.neighbors(current.0);
+
+        for &neighbor in neighbors {
+            if seen.insert(neighbor) {
+                let dist = dataset.compare(query, neighbor as usize).to_f32().unwrap();
+                frontier.push((neighbor, dist));
+            }
+        }
+
+        frontier.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+
+        if frontier.len() > beam_width {
+            frontier.truncate(beam_width);
+        }
+
+        steps.push(TransparentBeamStep {
+            beam: frontier.iter().map(|(id, _)| *id).collect(),
+            expanded: current.0,
+        });
+
+        if let Some(l) = limit {
+            if visited.len() >= l {
+                break;
+            }
+        }
+    }
+
+    (frontier, visited, steps)
+}
+
 pub fn beam_search<T>(
     query: &[T],
     graph: &dyn Graph,
@@ -60,6 +126,7 @@ pub fn beam_search<T>(
     beam_width: usize,
     limit: Option<usize>,
 ) -> Vec<IndexT> {
-    let (frontier, _visited) = beam_search_with_visited(query, graph, dataset, start, beam_width, limit);
+    let (frontier, _visited) =
+        beam_search_with_visited(query, graph, dataset, start, beam_width, limit);
     frontier.into_iter().map(|(id, _)| id).collect()
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -1,14 +1,15 @@
 //! Python bindings for the scratch library
 //! This module is only compiled when the "python" feature is enabled
 
-use pyo3::prelude::*;
-use numpy::{PyArray1, PyReadonlyArray2, PyReadonlyArray1};
+use crate::constructions::neighbor_selection::{naive_semi_greedy_prune, PairwiseDistancesHandler};
+use crate::constructions::slow_preprocessing::build_global_local_graph;
+use crate::data_handling::dataset::Subset;
 use crate::data_handling::dataset::VectorDataset;
 use crate::data_handling::dataset_traits::Dataset;
-use crate::graph::{VectorGraph, MutableGraph, IndexT};
-use crate::data_handling::dataset::Subset;
-use crate::constructions::slow_preprocessing::build_global_local_graph;
-use crate::constructions::neighbor_selection::{naive_semi_greedy_prune, PairwiseDistancesHandler};
+use crate::graph::{IndexT, MutableGraph, VectorGraph};
+use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2};
+use pyo3::prelude::*;
+use pyo3::IntoPyObjectExt;
 use rayon::iter::IntoParallelIterator;
 use rayon::prelude::*;
 
@@ -24,134 +25,147 @@ impl PyVectorDataset {
         let array = data.as_array();
         let n = array.shape()[0];
         let dim = array.shape()[1];
-        
+
         // Create a contiguous copy of the data
         let data_vec: Vec<f32> = array.iter().copied().collect();
-        
+
         Ok(PyVectorDataset {
             dataset: VectorDataset::new(data_vec.into_boxed_slice(), n, dim),
         })
     }
-    
+
     #[getter]
     fn get_n(&self) -> usize {
         self.dataset.n
     }
-    
+
     #[getter]
     fn get_dim(&self) -> usize {
         self.dataset.dim
     }
-    
+
     fn get_vector(&self, idx: usize, py: Python<'_>) -> PyResult<PyObject> {
         if idx >= self.dataset.n {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for dataset with {} elements", idx, self.dataset.n)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for dataset with {} elements",
+                idx, self.dataset.n
+            )));
         }
-        
+
         let vector = self.dataset.get(idx);
-        Ok(PyArray1::from_slice(py, vector).to_object(py))
+        Ok(PyArray1::from_slice(py, vector).into_py_any(py)?)
     }
-    
+
     fn compare_internal(&self, i: usize, j: usize) -> f64 {
         Dataset::compare_internal(&self.dataset, i, j)
     }
-    
+
     fn compare(&self, query: PyReadonlyArray1<f32>, i: usize) -> PyResult<f64> {
         if i >= self.dataset.n {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for dataset with {} elements", i, self.dataset.n)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for dataset with {} elements",
+                i, self.dataset.n
+            )));
         }
-        
+
         let query_slice = query.as_slice()?;
         if query_slice.len() != self.dataset.dim {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Query dimension {} does not match dataset dimension {}", 
-                        query_slice.len(), self.dataset.dim)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Query dimension {} does not match dataset dimension {}",
+                query_slice.len(),
+                self.dataset.dim
+            )));
         }
-        
+
         Ok(Dataset::compare(&self.dataset, query_slice, i))
     }
-    
+
     fn size(&self) -> usize {
         Dataset::size(&self.dataset)
     }
-    
-    fn brute_force(&self, query: PyReadonlyArray1<f32>, _py: Python<'_>) -> PyResult<Vec<(usize, f32)>> {
+
+    fn brute_force(
+        &self,
+        query: PyReadonlyArray1<f32>,
+        _py: Python<'_>,
+    ) -> PyResult<Vec<(usize, f32)>> {
         let query_slice = query.as_slice()?;
         if query_slice.len() != self.dataset.dim {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Query dimension {} does not match dataset dimension {}", 
-                        query_slice.len(), self.dataset.dim)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Query dimension {} does not match dataset dimension {}",
+                query_slice.len(),
+                self.dataset.dim
+            )));
         }
-        
+
         let results = Dataset::brute_force(&self.dataset, query_slice);
         Ok(results.into_vec())
     }
-    
+
     fn brute_force_internal(&self, q: usize, _py: Python<'_>) -> PyResult<Vec<(usize, f32)>> {
         if q >= self.dataset.n {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for dataset with {} elements", q, self.dataset.n)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for dataset with {} elements",
+                q, self.dataset.n
+            )));
         }
-        
+
         let results = Dataset::brute_force_internal(&self.dataset, q);
         Ok(results.into_vec())
     }
-    
+
     fn brute_force_subset(
-        &self, 
-        query: PyReadonlyArray1<f32>, 
-        subset: Vec<usize>, 
-        _py: Python<'_>
+        &self,
+        query: PyReadonlyArray1<f32>,
+        subset: Vec<usize>,
+        _py: Python<'_>,
     ) -> PyResult<Vec<(usize, f32)>> {
         let query_slice = query.as_slice()?;
         if query_slice.len() != self.dataset.dim {
-            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(
-                format!("Query dimension {} does not match dataset dimension {}", 
-                        query_slice.len(), self.dataset.dim)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Query dimension {} does not match dataset dimension {}",
+                query_slice.len(),
+                self.dataset.dim
+            )));
         }
-        
+
         // Validate subset indices
         for &idx in &subset {
             if idx >= self.dataset.n {
-                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                    format!("Subset index {} out of bounds for dataset with {} elements", idx, self.dataset.n)
-                ));
+                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                    "Subset index {} out of bounds for dataset with {} elements",
+                    idx, self.dataset.n
+                )));
             }
         }
-        
+
         let results = Dataset::brute_force_subset(&self.dataset, query_slice, &subset);
         Ok(results.into_vec())
     }
-    
+
     fn brute_force_subset_internal(
-        &self, 
-        q: usize, 
+        &self,
+        q: usize,
         subset: Vec<usize>,
-        _py: Python<'_>
+        _py: Python<'_>,
     ) -> PyResult<Vec<(usize, f32)>> {
         if q >= self.dataset.n {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for dataset with {} elements", q, self.dataset.n)
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for dataset with {} elements",
+                q, self.dataset.n
+            )));
         }
-        
+
         // Validate subset indices
         for &idx in &subset {
             if idx >= self.dataset.n {
-                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                    format!("Subset index {} out of bounds for dataset with {} elements", idx, self.dataset.n)
-                ));
+                return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                    "Subset index {} out of bounds for dataset with {} elements",
+                    idx, self.dataset.n
+                )));
             }
         }
-        
+
         let results = Dataset::brute_force_subset_internal(&self.dataset, q, &subset);
         Ok(results.into_vec())
     }
@@ -161,20 +175,27 @@ impl PyVectorDataset {
         let nested_boxed_distances = (0..self.dataset.size())
             .into_par_iter()
             .map(|i| {
-                self.dataset.brute_force_internal(i)
+                self.dataset
+                    .brute_force_internal(i)
                     .iter()
                     .map(|(j, dist)| (*j as IndexT, *dist))
                     .collect::<Box<[(IndexT, f32)]>>()
             })
             .collect::<Box<[Box<[(IndexT, f32)]>]>>();
-        
+
         let pairwise_distances = PairwiseDistancesHandler::new(nested_boxed_distances);
-        
+
         // Build the graph
         let graph = build_global_local_graph(&self.dataset, |center, candidates| {
-            naive_semi_greedy_prune(center, candidates, &self.dataset, alpha, &pairwise_distances)
+            naive_semi_greedy_prune(
+                center,
+                candidates,
+                &self.dataset,
+                alpha,
+                &pairwise_distances,
+            )
         });
-        
+
         Ok(PyVectorGraph { graph })
     }
 }
@@ -207,13 +228,15 @@ impl PyVectorGraph {
 
     fn get_neighborhood(&self, i: u32, py: Python<'_>) -> PyResult<PyObject> {
         if i >= self.graph.n() as u32 {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for graph with {} nodes", i, self.graph.n())
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for graph with {} nodes",
+                i,
+                self.graph.n()
+            )));
         }
-        
+
         let neighbors = self.graph.get_neighborhood(i);
-        Ok(PyArray1::from_slice(py, neighbors).to_object(py))
+        Ok(PyArray1::from_slice(py, neighbors).into_py_any(py)?)
     }
 
     fn total_edges(&self) -> usize {
@@ -223,27 +246,70 @@ impl PyVectorGraph {
     fn max_degree(&self) -> usize {
         self.graph.max_degree()
     }
-    
+
     fn add_neighbor(&mut self, from: u32, to: u32) -> PyResult<()> {
         if from >= self.graph.n() as u32 || to >= self.graph.n() as u32 {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index out of bounds for graph with {} nodes", self.graph.n())
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index out of bounds for graph with {} nodes",
+                self.graph.n()
+            )));
         }
-        
+
         self.graph.add_neighbor(from, to);
         Ok(())
     }
 
     fn set_neighborhood(&mut self, i: u32, neighborhood: Vec<u32>) -> PyResult<()> {
         if i >= self.graph.n() as u32 {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for graph with {} nodes", i, self.graph.n())
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for graph with {} nodes",
+                i,
+                self.graph.n()
+            )));
         }
-        
+
         self.graph.set_neighborhood(i, &neighborhood);
         Ok(())
+    }
+
+    fn transparent_beam_search(
+        &self,
+        query: PyReadonlyArray1<f32>,
+        dataset: &PyVectorDataset,
+        start: u32,
+        beam_width: usize,
+        limit: Option<usize>,
+    ) -> PyResult<(Vec<(u32, f32)>, Vec<(u32, f32)>, Vec<(Vec<u32>, u32)>)> {
+        if start >= self.graph.n() as u32 {
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Start {} out of bounds for graph with {} nodes",
+                start,
+                self.graph.n()
+            )));
+        }
+
+        let query_slice = query.as_slice()?;
+        if query_slice.len() != dataset.dataset.dim {
+            return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
+                "Query dimension {} does not match dataset dimension {}",
+                query_slice.len(),
+                dataset.dataset.dim
+            )));
+        }
+
+        let (frontier, visited, steps) = crate::graph::transparent_beam_search(
+            query_slice,
+            &self.graph,
+            &dataset.dataset,
+            start,
+            beam_width,
+            limit,
+        );
+
+        let steps_py: Vec<(Vec<u32>, u32)> =
+            steps.into_iter().map(|s| (s.beam, s.expanded)).collect();
+
+        Ok((frontier, visited, steps_py))
     }
 }
 
@@ -258,7 +324,7 @@ impl PySubset {
     fn new(dataset: &PyVectorDataset, indices: Vec<usize>) -> Self {
         // Create a new VectorDataset to pass to Subset
         let new_dataset = Box::new(dataset.dataset.clone());
-        
+
         PySubset {
             subset: Subset::new(new_dataset, indices),
         }
@@ -268,37 +334,40 @@ impl PySubset {
     fn size(&self) -> usize {
         self.subset.size()
     }
-    
+
     fn get_vector(&self, idx: usize, py: Python<'_>) -> PyResult<PyObject> {
         if idx >= self.subset.size() {
-            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(
-                format!("Index {} out of bounds for subset with {} elements", idx, self.subset.size())
-            ));
+            return Err(PyErr::new::<pyo3::exceptions::PyIndexError, _>(format!(
+                "Index {} out of bounds for subset with {} elements",
+                idx,
+                self.subset.size()
+            )));
         }
-        
+
         let vector = self.subset.get(idx);
-        Ok(PyArray1::from_slice(py, vector).to_object(py))
+        Ok(PyArray1::from_slice(py, vector).into_py_any(py)?)
     }
-    
+
     fn build_global_local_graph(&self, alpha: f32) -> PyResult<PyVectorGraph> {
         // Calculate pairwise distances
         let nested_boxed_distances = (0..self.subset.size())
             .into_par_iter()
             .map(|i| {
-                self.subset.brute_force_internal(i)
+                self.subset
+                    .brute_force_internal(i)
                     .iter()
                     .map(|(j, dist)| (*j as IndexT, *dist))
                     .collect::<Box<[(IndexT, f32)]>>()
             })
             .collect::<Box<[Box<[(IndexT, f32)]>]>>();
-        
+
         let pairwise_distances = PairwiseDistancesHandler::new(nested_boxed_distances);
-        
+
         // Build the graph
         let graph = build_global_local_graph(&self.subset, |center, candidates| {
             naive_semi_greedy_prune(center, candidates, &self.subset, alpha, &pairwise_distances)
         });
-        
+
         Ok(PyVectorGraph { graph })
     }
 }


### PR DESCRIPTION
## Summary
- implement `TransparentBeamStep` and `transparent_beam_search` for tracking search
- expose the new search through `PyVectorGraph.transparent_beam_search`
- add a Python example script that plots search progress
- fix dataset recursion bug and remove unused import
- use `into_py_any` for python array conversions

## Testing
- `cargo test --lib`
- `cargo build --features python`


------
https://chatgpt.com/codex/tasks/task_e_687971e45d10833297d59f8f7a5f0ea2