### PR TITLE
Refactor CLI to use Clap

### DIFF
--- a/src/bin/graph_info.rs
+++ b/src/bin/graph_info.rs
@@ -1,19 +1,22 @@
+use clap::{Arg, Command};
 use std::collections::HashMap;
-use std::env;
 use std::process;
 use std::time::Instant;
 
 use scratch::graph::ClassicGraph;
 
 fn main() {
-    // Get the filename from command-line arguments
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 2 {
-        eprintln!("Usage: {} <graph_file>", args[0]);
-        process::exit(1);
-    }
+    let matches = Command::new("graph_info")
+        .arg(
+            Arg::new("graph")
+                .long("graph")
+                .short('g')
+                .help("Path to graph file")
+                .required(true),
+        )
+        .get_matches();
 
-    let graph_file = &args[1];
+    let graph_file = matches.get_one::<String>("graph").unwrap();
     println!("Reading graph from file: {}", graph_file);
 
     // Measure the time it takes to read the graph

--- a/src/bin/graph_roundtrip.rs
+++ b/src/bin/graph_roundtrip.rs
@@ -1,4 +1,4 @@
-use std::env;
+use clap::{Arg, Command};
 use std::path::Path;
 use std::process;
 use std::time::Instant;
@@ -8,15 +8,31 @@ use scratch::graph::ClassicGraph;
 /// This utility demonstrates reading a graph from one file and writing it to another
 /// It helps test the roundtrip functionality and provides information about both processes
 fn main() {
-    // Get the filename from command-line arguments
-    let args: Vec<String> = env::args().collect();
-    if args.len() < 3 {
-        eprintln!("Usage: {} <input_graph_file> <output_graph_file>", args[0]);
-        process::exit(1);
-    }
+    let matches = Command::new("graph_roundtrip")
+        .arg(
+            Arg::new("input")
+                .long("input")
+                .short('i')
+                .help("Input graph file")
+                .required(true),
+        )
+        .arg(
+            Arg::new("output")
+                .long("output")
+                .short('o')
+                .help("Output graph file")
+                .required(true),
+        )
+        .arg(
+            Arg::new("verify")
+                .long("verify")
+                .action(clap::ArgAction::SetTrue)
+                .help("Verify written file"),
+        )
+        .get_matches();
 
-    let input_file = &args[1];
-    let output_file = &args[2];
+    let input_file = matches.get_one::<String>("input").unwrap();
+    let output_file = matches.get_one::<String>("output").unwrap();
 
     if !Path::new(input_file).exists() {
         eprintln!("Input file does not exist: {}", input_file);
@@ -85,7 +101,7 @@ fn main() {
     println!("Roundtrip complete!");
 
     // Optional: verify the written file
-    if args.len() > 3 && args[3] == "--verify" {
+    if matches.get_flag("verify") {
         println!("\nVerifying written file...");
 
         let start_verify = Instant::now();

--- a/src/util/dataset.rs
+++ b/src/util/dataset.rs
@@ -1,0 +1,22 @@
+use std::path::{Path, PathBuf};
+
+pub struct DatasetPaths {
+    pub base: PathBuf,
+    pub query: PathBuf,
+    pub gt: PathBuf,
+    pub outputs: PathBuf,
+}
+
+pub fn infer_dataset_paths(dataset: &str) -> DatasetPaths {
+    let dataset_root = if Path::new(dataset).exists() {
+        PathBuf::from(dataset)
+    } else {
+        PathBuf::from("data").join(dataset)
+    };
+    DatasetPaths {
+        base: dataset_root.join("base.fbin"),
+        query: dataset_root.join("query.fbin"),
+        gt: dataset_root.join("GT"),
+        outputs: dataset_root.join("outputs"),
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub mod dataset;
+pub mod duplicates;
 pub mod ground_truth;
 pub mod recall;
-pub mod duplicates;


### PR DESCRIPTION
## Summary
- add dataset path helper
- migrate CLI code in binaries to Clap
- infer dataset paths from dataset argument with overridable base/query/gt/graph options

## Testing
- `cargo test --quiet` *(fails: doctest stack overflow)*

------
https://chatgpt.com/codex/tasks/task_e_687c31a2aa2c83328be62907b27a19ec