### PR TITLE
Expose clique utility to Python and add clique histogram script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "scratch"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "criterion",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scratch"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/python/plot_clique_histogram.py
+++ b/python/plot_clique_histogram.py
@@ -1,0 +1,42 @@
+"""Plot a histogram of maximal clique sizes in a Vamana graph."""
+
+import argparse
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+import scratch
+from utils import graph_file_to_list_of_lists
+
+
+def plot_clique_histogram(graph_file: Path, output_file: Path) -> None:
+    """Plot a histogram of maximal clique sizes in ``graph_file``."""
+
+    neighborhoods = graph_file_to_list_of_lists(graph_file)
+    graph = scratch.PyVectorGraph(neighborhoods)
+    cliques = graph.maximal_cliques()
+    sizes = [len(c) for c in cliques]
+
+    bins = np.arange(1, max(sizes) + 2) - 0.5
+    plt.hist(sizes, bins=bins, edgecolor="black")
+    plt.xlabel("Clique size")
+    plt.ylabel("Frequency")
+    plt.title("Histogram of maximal clique sizes")
+    plt.xticks(range(1, max(sizes) + 1))
+    plt.savefig(output_file, bbox_inches="tight", dpi=300)
+    plt.close()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Plot a histogram of maximal clique sizes in a Vamana graph"
+    )
+    parser.add_argument("--graph", type=Path, required=True, help="Path to graph file")
+    parser.add_argument(
+        "--output", type=Path, required=True, help="Path to output image file"
+    )
+    args = parser.parse_args()
+
+    plot_clique_histogram(args.graph, args.output)
+

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "scratch"
-version = "0.1.0"
+version = "0.1.1"
 description = "Vector dataset library with nearest neighbor search"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -704,7 +704,7 @@ wheels = [
 
 [[package]]
 name = "scratch"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "ipykernel" },

--- a/src/python.rs
+++ b/src/python.rs
@@ -7,6 +7,7 @@ use crate::data_handling::dataset::Subset;
 use crate::data_handling::dataset::VectorDataset;
 use crate::data_handling::dataset_traits::Dataset;
 use crate::graph::{IndexT, MutableGraph, VectorGraph};
+use crate::util::clique;
 use numpy::{PyArray1, PyReadonlyArray1, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::IntoPyObjectExt;
@@ -246,6 +247,10 @@ impl PyVectorGraph {
 
     fn max_degree(&self) -> usize {
         self.graph.max_degree()
+    }
+
+    fn maximal_cliques(&self) -> Vec<Vec<u32>> {
+        clique::maximal_cliques(&self.graph)
     }
 
     fn add_neighbor(&mut self, from: u32, to: u32) -> PyResult<()> {


### PR DESCRIPTION
## Summary
- expose maximal clique enumeration in the Python bindings
- add script to plot a histogram of clique sizes from a Vamana graph

## Testing
- `cargo test`
- `cargo test --features python`
- `source .venv/bin/activate && python -m pytest python/test_vector_dataset.py` *(fails: ModuleNotFoundError: No module named 'scratch')*

------
https://chatgpt.com/codex/tasks/task_e_689147defe388332b732a27c09b828f5