### PR TITLE
Rename SqEuclidean to DenseVector with numeric and static bounds

### DIFF
--- a/src/bin/build_compacted_vamana.rs
+++ b/src/bin/build_compacted_vamana.rs
@@ -105,7 +105,10 @@ fn main() {
     // build the graph, or load it from disk if it exists
     start = Instant::now();
 
-    let graph_path = matches.get_one::<String>("graph").map(PathBuf::from).unwrap_or(data_path.parent().unwrap().join("outputs/vamana.graph"));
+    let graph_path = matches
+        .get_one::<String>("graph")
+        .map(PathBuf::from)
+        .unwrap_or(data_path.parent().unwrap().join("outputs/vamana.graph"));
     let graph: VectorGraph;
     if graph_path.exists() {
         graph = ClassicGraph::read(graph_path.to_str().unwrap())
@@ -142,7 +145,8 @@ fn main() {
         queries.size(),
         elapsed,
         queries.size().to_f64().unwrap() / elapsed.as_secs_f64(),
-        (get_distance_comparison_count() - prev_distance_comparisons) as f64 / queries.size().to_f64().unwrap()
+        (get_distance_comparison_count() - prev_distance_comparisons) as f64
+            / queries.size().to_f64().unwrap()
     );
 
     // Load ground truth and compute recall
@@ -232,7 +236,12 @@ fn main() {
     //     independent_cliques.iter().max_by_key(|c| c.len()).unwrap()
     // );
 
-    println!("compacted graph should have {} primary points and {} secondary points", graph.n() - independent_cliques.iter().map(|c| c.len()).sum::<usize>() + independent_cliques.len(), independent_cliques.iter().map(|c| c.len()).sum::<usize>() - independent_cliques.len());
+    println!(
+        "compacted graph should have {} primary points and {} secondary points",
+        graph.n() - independent_cliques.iter().map(|c| c.len()).sum::<usize>()
+            + independent_cliques.len(),
+        independent_cliques.iter().map(|c| c.len()).sum::<usize>() - independent_cliques.len()
+    );
 
     let independent_cliques_box: Box<[Box<[IndexT]>]> = independent_cliques
         .into_iter()
@@ -246,8 +255,14 @@ fn main() {
     let elapsed = start.elapsed();
     println!("Built compacted graph in {elapsed:?}");
 
-    println!("primary points: {:?}", compacted_graph.primary_points().len());
-    println!("secondary points: {:?}", compacted_graph.secondary_points().len());
+    println!(
+        "primary points: {:?}",
+        compacted_graph.primary_points().len()
+    );
+    println!(
+        "secondary points: {:?}",
+        compacted_graph.secondary_points().len()
+    );
 
     let start = Instant::now();
     let prev_distance_comparisons = get_distance_comparison_count();
@@ -311,7 +326,10 @@ fn main() {
         .map(|i| recall(results[i].as_slice(), gt.get_neighbors(i)))
         .sum::<f64>()
         / results.len().to_f64().unwrap();
-    println!("Exhaustive primary points recall: {exhaustive_primary_points_recall:.5} (Expected: {})", compacted_graph.primary_points().len() as f64 / compacted_graph.graph_size() as f64);
+    println!(
+        "Exhaustive primary points recall: {exhaustive_primary_points_recall:.5} (Expected: {})",
+        compacted_graph.primary_points().len() as f64 / compacted_graph.graph_size() as f64
+    );
 
     let start = Instant::now();
     let prev_distance_comparisons = get_distance_comparison_count();
@@ -343,5 +361,11 @@ fn main() {
         }
     }
 
-    println!("Representatives with nearest neighbor in clique: {} ({:.2}%)", primary_points_with_nearest_neighbor_in_clique, primary_points_with_nearest_neighbor_in_clique as f64 / compacted_graph.get_posting_lists().len() as f64 * 100.0);
+    println!(
+        "Representatives with nearest neighbor in clique: {} ({:.2}%)",
+        primary_points_with_nearest_neighbor_in_clique,
+        primary_points_with_nearest_neighbor_in_clique as f64
+            / compacted_graph.get_posting_lists().len() as f64
+            * 100.0
+    );
 }

--- a/src/data_handling/dataset.rs
+++ b/src/data_handling/dataset.rs
@@ -3,18 +3,18 @@
 pub use super::distance_matrix::DistanceMatrix;
 pub use super::subset::Subset;
 
-use std::{ops::Sub, path::Path};
+use std::path::Path;
 
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 
 use crate::{
-    distance::{euclidean, SqEuclidean},
+    distance::{euclidean, DenseVector},
     graph::IndexT,
 };
 
-use super::dataset_traits::{Dataset, Numeric};
+use super::dataset_traits::Dataset;
 
-impl<T: Numeric + SqEuclidean> Dataset<T> for VectorDataset<T> {
+impl<T: DenseVector> Dataset<T> for VectorDataset<T> {
     fn compare_internal(&self, i: usize, j: usize) -> f64 {
         self.compare_euclidean(i, j)
     }
@@ -30,16 +30,13 @@ impl<T: Numeric + SqEuclidean> Dataset<T> for VectorDataset<T> {
 }
 
 #[derive(Debug, Clone)]
-pub struct VectorDataset<T: Numeric + SqEuclidean> {
+pub struct VectorDataset<T: DenseVector> {
     data: Box<[T]>,
     pub n: usize,
     pub dim: usize,
 }
 
-impl<T: Numeric + SqEuclidean> VectorDataset<T>
-where
-    T: Copy + Into<f64> + Sub<Output = T>,
-{
+impl<T: DenseVector> VectorDataset<T> {
     pub fn new(data: Box<[T]>, n: usize, dim: usize) -> VectorDataset<T> {
         assert!(
             data.len() == n * dim,

--- a/src/data_handling/fbin.rs
+++ b/src/data_handling/fbin.rs
@@ -6,13 +6,12 @@ use std::path::Path;
 
 use memmap2::Mmap;
 
-use crate::distance::SqEuclidean;
+use crate::distance::DenseVector;
 
 use super::dataset::VectorDataset;
-use super::dataset_traits::Numeric;
 
 /// read a dataset from an fbin file
-pub fn read_fbin<T: Numeric + SqEuclidean>(path: &Path) -> VectorDataset<T> {
+pub fn read_fbin<T: DenseVector>(path: &Path) -> VectorDataset<T> {
     let file = File::open(path).expect("could not open file");
     let mmap = unsafe { Mmap::map(&file).expect("could not mmap file") };
     let mut reader = BufReader::new(&*mmap);
@@ -48,10 +47,7 @@ pub fn read_fbin<T: Numeric + SqEuclidean>(path: &Path) -> VectorDataset<T> {
 }
 
 /// reads only a subset of the dataset from an fbin file, but is otherwise the same as `read_fbin`
-pub fn read_fbin_subset<T: Numeric + SqEuclidean>(
-    path: &Path,
-    subset_size: usize,
-) -> VectorDataset<T> {
+pub fn read_fbin_subset<T: DenseVector>(path: &Path, subset_size: usize) -> VectorDataset<T> {
     let file = File::open(path).expect("could not open file");
     let mmap = unsafe { Mmap::map(&file).expect("could not mmap file") };
     let mut reader = BufReader::new(&*mmap);

--- a/src/data_handling/subset.rs
+++ b/src/data_handling/subset.rs
@@ -2,7 +2,7 @@
 
 use std::sync::Arc;
 
-use crate::distance::SqEuclidean;
+use crate::distance::DenseVector;
 
 use super::dataset_traits::{Dataset, Numeric};
 
@@ -12,7 +12,7 @@ pub struct Subset<T> {
     indices: Vec<usize>,
 }
 
-impl<T: Numeric + SqEuclidean> Subset<T> {
+impl<T: DenseVector> Subset<T> {
     pub fn new(dataset: Arc<dyn Dataset<T>>, indices: Vec<usize>) -> Self {
         Subset { dataset, indices }
     }

--- a/src/distance/euclidean_.rs
+++ b/src/distance/euclidean_.rs
@@ -1,5 +1,3 @@
-use std::ops::Sub;
-
 use rand_distr::num_traits::ToPrimitive;
 
 #[cfg(feature = "dcmp")]
@@ -29,7 +27,7 @@ static DIST_CMP_COUNT: AtomicU64 = AtomicU64::new(0);
 /// ```
 pub fn euclidean<T>(a: &[T], b: &[T]) -> f32
 where
-    T: Copy + Into<f64> + Sub<Output = T> + SqEuclidean,
+    T: DenseVector,
 {
     #[cfg(feature = "dcmp")]
     {
@@ -50,7 +48,7 @@ where
 
 pub fn sq_euclidean<T>(a: &[T], b: &[T]) -> f32
 where
-    T: Copy + Into<f64> + SqEuclidean,
+    T: DenseVector,
 {
     #[cfg(feature = "dcmp")]
     {
@@ -69,7 +67,9 @@ where
     T::sq_euclidean(a, b)
 }
 
-pub trait SqEuclidean {
+use crate::data_handling::dataset_traits::Numeric;
+
+pub trait DenseVector: Numeric + 'static {
     fn sq_euclidean(a: &[Self], b: &[Self]) -> f32
     where
         Self: Sized;
@@ -81,21 +81,21 @@ pub trait SqEuclidean {
     }
 }
 
-impl SqEuclidean for f32 {
+impl DenseVector for f32 {
     fn sq_euclidean(a: &[Self], b: &[Self]) -> f32 {
         use simsimd::SpatialSimilarity;
         f32::sqeuclidean(a, b).unwrap().to_f32().unwrap()
     }
 }
 
-impl SqEuclidean for f64 {
+impl DenseVector for f64 {
     fn sq_euclidean(a: &[Self], b: &[Self]) -> f32 {
         use simsimd::SpatialSimilarity;
         f64::sqeuclidean(a, b).unwrap().to_f32().unwrap()
     }
 }
 
-impl SqEuclidean for i32 {
+impl DenseVector for i32 {
     fn sq_euclidean(a: &[Self], b: &[Self]) -> f32 {
         let a: Vec<f32> = a.iter().map(|&x| x as f32).collect();
         let b: Vec<f32> = b.iter().map(|&x| x as f32).collect();
@@ -103,7 +103,7 @@ impl SqEuclidean for i32 {
     }
 }
 
-impl SqEuclidean for i8 {
+impl DenseVector for i8 {
     fn sq_euclidean(a: &[Self], b: &[Self]) -> f32 {
         use simsimd::SpatialSimilarity;
         i8::sqeuclidean(a, b).unwrap().to_f32().unwrap()

--- a/src/distance/mod.rs
+++ b/src/distance/mod.rs
@@ -1,6 +1,6 @@
 mod euclidean_;
 
-pub use self::euclidean_::{euclidean, get_distance_comparison_count, sq_euclidean, SqEuclidean};
+pub use self::euclidean_::{euclidean, get_distance_comparison_count, sq_euclidean, DenseVector};
 
 pub enum Distance {
     Euclidean,

--- a/src/util/duplicates.rs
+++ b/src/util/duplicates.rs
@@ -3,8 +3,8 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use crate::data_handling::dataset::{Subset, VectorDataset};
-use crate::data_handling::dataset_traits::{Dataset, Numeric};
-use crate::distance::SqEuclidean;
+use crate::data_handling::dataset_traits::Dataset;
+use crate::distance::DenseVector;
 use crate::graph::IndexT;
 use crate::util::DSU;
 
@@ -16,7 +16,7 @@ const EXHAUSTIVE_CUTOFF: usize = 1000;
 /// Each set contains the indices of vectors that are identical.
 pub fn duplicate_sets<T>(dataset: Arc<VectorDataset<T>>, radius: Option<f64>) -> Vec<HashSet<usize>>
 where
-    T: Numeric + SqEuclidean + 'static,
+    T: DenseVector,
 {
     // we use recursive parallel bisection to winnow down the search space;
     // once we have < 100 vectors or we do a partition that doesn't reduce the number of vectors,
@@ -32,7 +32,7 @@ where
 /// recursive helper function to find duplicates in a subset of the dataset
 pub fn subset_duplicates<T>(subset: &Subset<T>, radius: f64) -> Vec<HashSet<usize>>
 where
-    T: Numeric + SqEuclidean + 'static,
+    T: DenseVector,
 {
     if subset.size() < EXHAUSTIVE_CUTOFF {
         return exhaustive_subset_duplicates(subset, radius);
@@ -83,7 +83,7 @@ where
 /// this is potentially approximate, but assumes equality is transitive, so might be wonky
 fn exhaustive_subset_duplicates<T>(subset: &Subset<T>, radius: f64) -> Vec<HashSet<usize>>
 where
-    T: Numeric + SqEuclidean,
+    T: DenseVector,
 {
     let mut equality_dsu = DSU::new(subset.size());
     for i in 0..subset.size() {


### PR DESCRIPTION
## Summary
- Introduce `DenseVector` trait combining numeric behavior and `'static`
- Update dataset, graph, and utility modules to rely on `DenseVector`
- Re-export `DenseVector` from distance module

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_6898ea9d30b883328e2910154a7b6e1d